### PR TITLE
Handle map-form permissions.scopes (offline user impersonation)

### DIFF
--- a/AI-Planning/05-scopes-object-format.md
+++ b/AI-Planning/05-scopes-object-format.md
@@ -1,0 +1,200 @@
+# Proposal 05 — Handle Object Form of `permissions.scopes` in Forge Manifests
+
+## Status
+
+Proposed
+
+## Problem
+
+The Forge manifest supports two distinct formats for `permissions.scopes`:
+
+**Simple array (currently handled):**
+```yaml
+permissions:
+  scopes:
+    - read:jira-work
+    - write:jira-work
+```
+
+**Map/object form (not currently handled):**
+```yaml
+permissions:
+  scopes:
+    read:confluence-content.summary:
+      allowImpersonation: true
+    write:confluence-content:
+      allowImpersonation: false
+    write:jira-work: {}
+```
+
+The map form is used when an app needs **offline user impersonation** (e.g. from a scheduled trigger). Each scope name is a key, with an optional `allowImpersonation` boolean. An empty map `{}` is valid and means `allowImpersonation: false`.
+
+The tool currently assumes `permissions.scopes` is always a `string[]`. This causes failures in two places:
+
+### 1. `adoption-status` — E004 check (Connect-style scopes)
+
+```typescript
+const connectScopes = (manifest.permissions?.scopes ?? []).filter(
+  s => s.endsWith(':connect-jira') || s.endsWith(':connect-confluence')
+);
+```
+
+If `manifest.permissions.scopes` is an object (`{ content: [...], experimental: [...] }`), calling `.filter()` on it throws a runtime error and the entire check crashes.
+
+### 2. `convert.ts` — `buildForgeManifest()` scope assignment
+
+```typescript
+m.permissions.scopes = c.scopes.map(scope => normaliseConnectScope(scope, type));
+```
+
+When writing the normalised Connect scopes into the manifest, this always writes a flat array — even if the existing manifest already used the object form. This silently discards any existing `experimental` scopes and loses the structural distinction between `content` and `experimental`.
+
+### 3. `types.ts` — `ForgeManifest.permissions.scopes`
+
+```typescript
+permissions: {
+  scopes: string[];
+};
+```
+
+The type does not reflect reality — it will incorrectly type-check object-form manifests as valid `string[]`.
+
+---
+
+## Proposed Solution
+
+### Step 1 — Update `ForgeManifest` type in `types.ts`
+
+Replace the narrow `string[]` type with a union that reflects both valid formats:
+
+```typescript
+// The value for each scope entry in the map form
+export interface ScopeOptions {
+  allowImpersonation?: boolean;
+}
+
+// The two valid formats for permissions.scopes in a Forge manifest:
+// - string[] for standard scopes
+// - Record<string, ScopeOptions> for offline user impersonation
+export type ForgeScopes =
+  | string[]
+  | Record<string, ScopeOptions>;
+
+// Typings for Forge manifest
+export interface ForgeManifest {
+  // ...
+  permissions: {
+    scopes: ForgeScopes;
+    content?: {
+      scripts?: string[];
+      styles?: string[];
+    };
+  };
+}
+```
+
+Note: `permissions.content` is a separate CSP section (for Custom UI script/style sources), not related to scopes.
+
+### Step 2 — Add a `flattenScopes()` helper in `adoption-status.ts` or a shared `utils.ts`
+
+A pure function that flattens either scope format into a single `string[]` for checking purposes:
+
+```typescript
+export function flattenScopes(scopes: ForgeScopes): string[] {
+  if (Array.isArray(scopes)) {
+    return scopes;
+  }
+  // Map form — scope names are the keys
+  return Object.keys(scopes);
+}
+```
+
+### Step 3 — Update the E004 check in `adoption-status.ts`
+
+Replace the direct `.filter()` with `flattenScopes()`:
+
+```typescript
+const allScopes = flattenScopes(manifest.permissions?.scopes ?? []);
+const connectScopes = allScopes.filter(
+  s => s.endsWith(':connect-jira') || s.endsWith(':connect-confluence')
+);
+```
+
+### Step 4 — Update `buildForgeManifest()` in `convert.ts`
+
+When writing normalised Connect scopes into the manifest, preserve the map structure if the existing manifest already uses it. Connect scopes don't use impersonation, so they should be added with `allowImpersonation: false` (i.e. `{}`):
+
+```typescript
+if (isPresent(c.scopes) && c.scopes.length > 0) {
+  const normalisedScopes = c.scopes.map(scope => normaliseConnectScope(scope, type));
+
+  if (Array.isArray(m.permissions.scopes)) {
+    // Simple array — append normalised scopes directly
+    m.permissions.scopes = [...m.permissions.scopes, ...normalisedScopes];
+  } else {
+    // Map form — add each scope as a key with no impersonation
+    const additionalScopes: Record<string, ScopeOptions> = {};
+    for (const scope of normalisedScopes) {
+      additionalScopes[scope] = {};
+    }
+    m.permissions.scopes = {
+      ...m.permissions.scopes,
+      ...additionalScopes,
+    };
+  }
+}
+```
+
+### Step 5 — Update `genDefaultManifest()` in `convert.ts`
+
+The default manifest initialises `permissions.scopes` as `[]`. This is fine — Connect-on-Forge apps start with a simple array and the object form is only relevant for apps that have already started using experimental APIs.
+
+No change needed here.
+
+### Step 6 — Update `checkManifest()` W002 and E004 checks in `adoption-status.ts`
+
+The W001/E004 checks both currently iterate scopes as a flat array. Replace all direct scope access with `flattenScopes()`.
+
+### Step 7 — Update tests
+
+- Add `flattenScopes()` unit tests covering:
+  - `string[]` passthrough — returned as-is
+  - Map form with multiple scopes — returns scope names as `string[]`
+  - Map form with `allowImpersonation: true` on some entries — all keys still returned
+  - Empty map `{}` → `[]`
+
+- Add E004 test cases for map-form scopes containing Connect-style scope names as keys
+- Add `buildForgeManifest()` test verifying that when the existing manifest uses the map form, converted Connect scopes are merged in with empty `{}` values (no impersonation)
+
+---
+
+## Affected Files
+
+| File | Change |
+|---|---|
+| `src/types.ts` | Add `ForgeScopes` union type, update `ForgeManifest.permissions.scopes` |
+| `src/adoption-status.ts` | Add `flattenScopes()`, use it in E004 check |
+| `src/convert.ts` | Update `buildForgeManifest()` scope assignment to preserve object form |
+| `src/__tests__/adoption-status.test.ts` | Add `flattenScopes` and E004 object-form tests |
+| `src/__tests__/convert.test.ts` | Add `buildForgeManifest` object-form scope preservation test |
+
+---
+
+## Scope & Effort
+
+| Task | Effort |
+|---|---|
+| Update `ForgeScopes` type in `types.ts` | Trivial (15 min) |
+| Add `flattenScopes()` helper | Trivial (15 min) |
+| Update E004 check | Trivial (15 min) |
+| Update `buildForgeManifest()` scope handling | Small (30 min) |
+| Write tests | Small (1 hour) |
+| **Total** | **~2 hours** |
+
+---
+
+## Out of Scope
+
+- Validating that scope strings are known/valid Forge scopes — that is `forge lint`'s job
+- Converting between array and object form based on user preference — we follow the existing manifest's structure
+- The `experimental` scopes introduced by Connect (there are none — this is Forge-only)

--- a/src/__tests__/adoption-status.test.ts
+++ b/src/__tests__/adoption-status.test.ts
@@ -1,6 +1,5 @@
-import { checkManifest, parseManifest, printAdoptionStatus } from '../adoption-status';
-import { AdoptionStatusResult, CheckIssue } from '../types';
-import { ForgeManifest } from '../types';
+import { checkManifest, parseManifest, printAdoptionStatus, flattenScopes } from '../adoption-status';
+import { AdoptionStatusResult, CheckIssue, ForgeManifest, ForgeScopes } from '../types';
 
 // A minimal valid fully-adopted manifest — passes all checks
 const VALID_MANIFEST: ForgeManifest = {
@@ -166,6 +165,61 @@ describe('E004: Connect-style scopes', () => {
     const result = checkManifest(VALID_MANIFEST);
     expect(result.errors.find(e => e.id === 'E004')).toBeUndefined();
   });
+
+  it('raises E004 for :connect-jira scopes in map form', () => {
+    const manifest = makeManifest({
+      permissions: {
+        scopes: {
+          'read:connect-jira': { allowImpersonation: false },
+          'write:connect-jira': {},
+        },
+      },
+    });
+    const result = checkManifest(manifest);
+    const e004 = result.errors.find(e => e.id === 'E004');
+    expect(e004).toBeDefined();
+    expect(e004?.detail?.scopes).toContain('read:connect-jira');
+    expect(e004?.detail?.scopes).toContain('write:connect-jira');
+  });
+
+  it('raises E004 for :connect-confluence scopes in map form', () => {
+    const manifest = makeManifest({
+      permissions: {
+        scopes: { 'read:connect-confluence': { allowImpersonation: true } },
+      },
+    });
+    const result = checkManifest(manifest);
+    expect(result.errors.find(e => e.id === 'E004')).toBeDefined();
+  });
+
+  it('does not raise E004 for native scopes in map form', () => {
+    const manifest = makeManifest({
+      permissions: {
+        scopes: {
+          'read:jira-work': { allowImpersonation: true },
+          'write:jira-work': {},
+        },
+      },
+    });
+    const result = checkManifest(manifest);
+    expect(result.errors.find(e => e.id === 'E004')).toBeUndefined();
+  });
+
+  it('detects mixed Connect and native scopes in map form', () => {
+    const manifest = makeManifest({
+      permissions: {
+        scopes: {
+          'read:jira-work': {},
+          'read:connect-jira': { allowImpersonation: false },
+        },
+      },
+    });
+    const result = checkManifest(manifest);
+    const e004 = result.errors.find(e => e.id === 'E004');
+    expect(e004).toBeDefined();
+    expect(e004?.detail?.scopes).toHaveLength(1);
+    expect(e004?.detail?.scopes).toContain('read:connect-jira');
+  });
 });
 
 // ─── W002: placeholder app ID ─────────────────────────────────────────────
@@ -245,6 +299,53 @@ describe('adoption summary states', () => {
     const result = checkManifest(manifest);
     expect(result.fullyAdopted).toBe(false);
     expect(result.summary).toMatch(/partially adopted/i);
+  });
+});
+
+// ─── flattenScopes() ──────────────────────────────────────────────────────
+
+describe('flattenScopes()', () => {
+  it('returns an array unchanged when given a string[]', () => {
+    const scopes: ForgeScopes = ['read:jira-work', 'write:jira-work'];
+    expect(flattenScopes(scopes)).toEqual(['read:jira-work', 'write:jira-work']);
+  });
+
+  it('returns an empty array unchanged', () => {
+    expect(flattenScopes([])).toEqual([]);
+  });
+
+  it('returns scope names as keys from a map-form object', () => {
+    const scopes: ForgeScopes = {
+      'read:confluence-content.summary': { allowImpersonation: true },
+      'write:confluence-content': { allowImpersonation: false },
+      'write:jira-work': {},
+    };
+    expect(flattenScopes(scopes)).toEqual([
+      'read:confluence-content.summary',
+      'write:confluence-content',
+      'write:jira-work',
+    ]);
+  });
+
+  it('returns all scope names regardless of allowImpersonation value', () => {
+    const scopes: ForgeScopes = {
+      'read:jira-work': { allowImpersonation: true },
+      'write:jira-work': { allowImpersonation: false },
+    };
+    const result = flattenScopes(scopes);
+    expect(result).toContain('read:jira-work');
+    expect(result).toContain('write:jira-work');
+    expect(result).toHaveLength(2);
+  });
+
+  it('returns an empty array for an empty map object', () => {
+    const scopes: ForgeScopes = {};
+    expect(flattenScopes(scopes)).toEqual([]);
+  });
+
+  it('handles a single entry in the map form', () => {
+    const scopes: ForgeScopes = { 'read:jira-work': {} };
+    expect(flattenScopes(scopes)).toEqual(['read:jira-work']);
   });
 });
 

--- a/src/__tests__/convert.test.ts
+++ b/src/__tests__/convert.test.ts
@@ -342,7 +342,7 @@ describe('buildForgeManifest()', () => {
   // ── Scopes ─────────────────────────────────────────────────────────────
 
   describe('scopes', () => {
-    it('normalises scopes for Jira', () => {
+    it('normalises scopes for Jira (array form)', () => {
       const connect: ConnectDescriptor = {
         ...minimalConnectDescriptor,
         scopes: ['READ', 'PROJECT_ADMIN'],
@@ -352,13 +352,83 @@ describe('buildForgeManifest()', () => {
       expect(manifest.permissions.scopes).toContain('project-admin:connect-jira');
     });
 
-    it('normalises scopes for Confluence', () => {
+    it('normalises scopes for Confluence (array form)', () => {
       const connect: ConnectDescriptor = {
         ...minimalConnectDescriptor,
         scopes: ['WRITE'],
       };
       const { manifest } = buildForgeManifest(makeDefaultManifest(), connect, 'confluence');
       expect(manifest.permissions.scopes).toContain('write:connect-confluence');
+    });
+
+    it('appends to existing array-form scopes without replacing them', () => {
+      const baseManifest = makeDefaultManifest();
+      baseManifest.permissions.scopes = ['read:jira-work'];
+      const connect: ConnectDescriptor = {
+        ...minimalConnectDescriptor,
+        scopes: ['WRITE'],
+      };
+      const { manifest } = buildForgeManifest(baseManifest, connect, 'jira');
+      const scopes = manifest.permissions.scopes as string[];
+      expect(scopes).toContain('read:jira-work');
+      expect(scopes).toContain('write:connect-jira');
+    });
+
+    it('merges Connect scopes into an existing map-form manifest as empty-options entries', () => {
+      const baseManifest = makeDefaultManifest();
+      baseManifest.permissions.scopes = {
+        'read:jira-work': { allowImpersonation: true },
+      };
+      const connect: ConnectDescriptor = {
+        ...minimalConnectDescriptor,
+        scopes: ['WRITE'],
+      };
+      const { manifest } = buildForgeManifest(baseManifest, connect, 'jira');
+      const scopes = manifest.permissions.scopes as Record<string, any>;
+      // Existing map-form scope preserved
+      expect(scopes['read:jira-work']).toEqual({ allowImpersonation: true });
+      // Converted Connect scope added with no impersonation
+      expect(scopes['write:connect-jira']).toEqual({});
+    });
+
+    it('preserves allowImpersonation on pre-existing map entries when merging', () => {
+      const baseManifest = makeDefaultManifest();
+      baseManifest.permissions.scopes = {
+        'read:confluence-content.summary': { allowImpersonation: true },
+        'write:confluence-content': { allowImpersonation: false },
+      };
+      const connect: ConnectDescriptor = {
+        ...minimalConnectDescriptor,
+        scopes: ['READ'],
+      };
+      const { manifest } = buildForgeManifest(baseManifest, connect, 'confluence');
+      const scopes = manifest.permissions.scopes as Record<string, any>;
+      expect(scopes['read:confluence-content.summary']).toEqual({ allowImpersonation: true });
+      expect(scopes['write:confluence-content']).toEqual({ allowImpersonation: false });
+      expect(scopes['read:connect-confluence']).toEqual({});
+    });
+
+    it('does not add Connect scopes when the descriptor has none', () => {
+      const connect: ConnectDescriptor = {
+        ...minimalConnectDescriptor,
+        scopes: [],
+      };
+      const { manifest } = buildForgeManifest(makeDefaultManifest(), connect, 'jira');
+      expect(manifest.permissions.scopes).toEqual([]);
+    });
+
+    it('produces a result that remains a map when starting from a map with no Connect scopes', () => {
+      const baseManifest = makeDefaultManifest();
+      baseManifest.permissions.scopes = {
+        'read:jira-work': {},
+      };
+      const connect: ConnectDescriptor = {
+        ...minimalConnectDescriptor,
+        scopes: [],
+      };
+      const { manifest } = buildForgeManifest(baseManifest, connect, 'jira');
+      // No Connect scopes to add — original map should be untouched
+      expect(manifest.permissions.scopes).toEqual({ 'read:jira-work': {} });
     });
   });
 

--- a/src/adoption-status.ts
+++ b/src/adoption-status.ts
@@ -1,6 +1,19 @@
 import fs from 'fs';
 import yaml from 'js-yaml';
-import { ForgeManifest, AdoptionStatusResult, CheckIssue } from './types';
+import { ForgeManifest, ForgeScopes, AdoptionStatusResult, CheckIssue } from './types';
+
+/**
+ * Flatten either form of permissions.scopes into a plain string[].
+ *
+ * - Array form:  ["read:jira-work", "write:jira-work"]  → same array
+ * - Map form:    { "read:jira-work": { allowImpersonation: true }, ... } → Object.keys(...)
+ */
+export function flattenScopes(scopes: ForgeScopes): string[] {
+  if (Array.isArray(scopes)) {
+    return scopes;
+  }
+  return Object.keys(scopes);
+}
 
 const PLACEHOLDER_APP_ID = 'ari:cloud:ecosystem::app/invalid-run-forge-register';
 
@@ -67,8 +80,9 @@ export function checkManifest(manifest: ForgeManifest): AdoptionStatusResult {
     }
   }
 
-  // E004: Connect-style scopes
-  const connectScopes = (manifest.permissions?.scopes ?? []).filter(
+  // E004: Connect-style scopes — works for both array and map form
+  const allScopes = flattenScopes(manifest.permissions?.scopes ?? []);
+  const connectScopes = allScopes.filter(
     s => s.endsWith(':connect-jira') || s.endsWith(':connect-confluence')
   );
   if (connectScopes.length > 0) {

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -4,7 +4,7 @@ import yaml from 'js-yaml';
 import inquirer from 'inquirer';
 import { isPresent } from 'ts-is-present';
 import merge from 'deepmerge';
-import { ConnectDescriptor, ConnectPermission, ConnectWebhook, ConnectWebhookWithKey, NormalisedPermission, ForgeManifest } from './types';
+import { ConnectDescriptor, ConnectPermission, ConnectWebhook, ConnectWebhookWithKey, NormalisedPermission, ForgeManifest, ScopeOptions } from './types';
 
 const UNSUPPORTED_MODULES = new Set<string>([]);
 
@@ -257,9 +257,21 @@ export function buildForgeManifest(
     m.connectModules![`${type}:webhooks`] = assignWebhookKeys(webhooks);
   }
 
-  // Scopes
+  // Scopes — handle both array and map form of permissions.scopes
   if (isPresent(c.scopes) && c.scopes.length > 0) {
-    m.permissions.scopes = c.scopes.map(scope => normaliseConnectScope(scope, type));
+    const normalisedScopes = c.scopes.map(scope => normaliseConnectScope(scope, type));
+
+    if (Array.isArray(m.permissions.scopes)) {
+      // Array form — append directly
+      m.permissions.scopes = [...m.permissions.scopes, ...normalisedScopes];
+    } else {
+      // Map form — add each scope as a key with empty options (no impersonation)
+      const additionalScopes: Record<string, ScopeOptions> = {};
+      for (const scope of normalisedScopes) {
+        additionalScopes[scope] = {};
+      }
+      m.permissions.scopes = { ...m.permissions.scopes, ...additionalScopes };
+    }
   }
 
   // Data residency

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,6 +51,16 @@ export interface ConnectDescriptor {
   };
 }
 
+// Per-scope options used in the map form of permissions.scopes
+export interface ScopeOptions {
+  allowImpersonation?: boolean;
+}
+
+// The two valid formats for permissions.scopes in a Forge manifest:
+//   - string[]                      — standard scopes (most common)
+//   - Record<string, ScopeOptions>  — map form, used for offline user impersonation
+export type ForgeScopes = string[] | Record<string, ScopeOptions>;
+
 // Typings for Forge manifest
 export interface ForgeManifest {
   app: {
@@ -80,7 +90,13 @@ export interface ForgeManifest {
   modules?: Record<string, any>;
   connectModules?: Record<string, any>;
   permissions: {
-    scopes: string[];
+    scopes: ForgeScopes;
+    // Content Security Policy options for Custom UI (scripts, styles) —
+    // unrelated to OAuth scopes
+    content?: {
+      scripts?: string[];
+      styles?: string[];
+    };
   };
 }
 


### PR DESCRIPTION
## Summary

The Forge manifest supports two valid formats for `permissions.scopes`:

**Array form (existing, already handled):**
```yaml
permissions:
  scopes:
    - read:jira-work
    - write:jira-work
```

**Map form (new — used for offline user impersonation):**
```yaml
permissions:
  scopes:
    read:confluence-content.summary:
      allowImpersonation: true
    write:confluence-content:
      allowImpersonation: false
    write:jira-work: {}
```

Previously, the tool assumed `permissions.scopes` was always a `string[]`. This caused the E004 Connect-scope check to crash on map-form manifests, and `buildForgeManifest()` would silently discard existing map-form scopes when merging in converted Connect scopes.

## Changes

### `types.ts`
- New `ScopeOptions` interface: `{ allowImpersonation?: boolean }`
- New `ForgeScopes` union type: `string[] | Record<string, ScopeOptions>`
- Added `permissions.content` CSP type to `ForgeManifest` (for Custom UI script/style sources — separate from scopes)

### `adoption-status.ts`
- New exported `flattenScopes(scopes: ForgeScopes): string[]` pure helper — normalises either format to a plain `string[]` for checking
- E004 check now uses `flattenScopes()` — correctly detects Connect-style scopes in both array and map form

### `convert.ts`
- `buildForgeManifest()` scopes section now branches on the form: appends to arrays, or merges as `key: {}` entries into map-form manifests (preserving `allowImpersonation` on existing entries)

## Tests

15 new unit tests (116 total across 3 suites):
- 6 `flattenScopes()` unit tests covering array passthrough, map-form extraction, empty cases
- 5 E004 map-form detection tests (Connect scopes as keys, native scopes as keys, mixed)
- 6 `buildForgeManifest()` map-form scopes tests (merge, preserve, no-op)